### PR TITLE
update READMEs for (to-be-)supported meta, commands, and notes; fix missing checkbox for `#LYRIC`

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -54,8 +54,9 @@ You shall then open `index.html` (not `src/index.html`) in your browser.
 - [ ] Show different branches side-by-side
 - Meta (common)
     - [x] `TITLE`
-    - [ ] `SUBTITLE`
+    - [x] `SUBTITLE`
     - [x] `BPM`
+    - [x] `MAKER`
     - [ ] `GENRE`
 - Meta (course-specific)
     - `COURSE`
@@ -69,6 +70,8 @@ You shall then open `index.html` (not `src/index.html`) in your browser.
     - [x] `LEVEL`
     - [x] `BALLOON`
     - [ ] `STYLE`
+    - [x] `NOTESDESIGNER0` - `NOTESDESIGNER6` (only 0-4 are recognized)
+    - [x] `TTROWBEAT` (for visualizing, maximum # of beats in one line)
 - Notes
     - [x] `0` (empty)
     - [x] `1` (Don)
@@ -86,6 +89,8 @@ You shall then open `index.html` (not `src/index.html`) in your browser.
     - [x] `D` (Fuse)
     - [x] `F` (ADLIB)
     - [x] `G` (Green/Purple)
+    - [ ] `H` (DRUMROLL or Don-roll)
+    - [ ] `I` (Drumroll or Ka-roll)
 - Commands
     - [x] `#START`
     - [x] `#END`
@@ -102,9 +107,10 @@ You shall then open `index.html` (not `src/index.html`) in your browser.
     - [x] `#E`
     - [x] `#M`
     - [x] `#BRANCHEND`
-    - `#LYRIC`
+    - [ ] `#LYRIC`
     - [ ] `#LEVELHOLD`
     - [ ] `#NEXTSONG`
+    - [x] `#TTBREAK` (for visualizing, wrap at the start of this measure)
 
 # Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ npm run build
 - [ ] 并列显示不同分歧轨道
 - 元信息（通用）
     - [x] `TITLE`
-    - [ ] `SUBTITLE`
+    - [x] `SUBTITLE`
     - [x] `BPM`
+    - [x] `MAKER`
     - [ ] `GENRE`
 - 元信息（各难度独立）
     - `COURSE`
@@ -69,6 +70,8 @@ npm run build
     - [x] `LEVEL`
     - [x] `BALLOON`
     - [ ] `STYLE`
+    - [x] `NOTESDESIGNER0` ~ `NOTESDESIGNER6` (仅0~4有效)
+    - [x] `TTROWBEAT`（图像化用，单行最大拍数）
 - 音符
     - [x] `0`（空）
     - [x] `1`（小咚）
@@ -86,6 +89,8 @@ npm run build
     - [x] `D`（紫色气球）
     - [x] `F`（隐藏音符）
     - [x] `G`（紫/绿音符）
+    - [ ] `H`（大滚奏或小咚滚奏开始）
+    - [ ] `I`（小滚奏或小咔滚奏开始）
 - 指令
     - [x] `#START`
     - [x] `#END`
@@ -105,6 +110,8 @@ npm run build
     - [ ] `#LYRIC`
     - [ ] `#LEVELHOLD`
     - [ ] `#NEXTSONG`
+    - [x] `#TTBREAK`（图像化用，在本小节首换行）
+
 # 致谢
 
 - [Snack](https://github.com/Snack-X)：项目的原作者


### PR DESCRIPTION
* newly supported meta: `SUBTITLE:`, `MAKER:`, & `NOTESDESIGNER<n>:`
* existent tja-tools extension meta: `TTROWBEAT:`
* existent tja-tools extension commands: `#TTBREAK`
* OpenTaiko-OutFox standardization notes: `H` & `I`